### PR TITLE
Add VS Code tasks for cargo commands

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,83 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cargo",
+			"command": "build",
+			"problemMatcher": [
+				"$rustc"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}/chess"
+			},
+			"group": "build",
+			"label": "rust: cargo build debug"
+		},
+		{
+			"type": "cargo",
+			"command": "build",
+			"args": [
+				"--release"
+			],
+			"problemMatcher": [
+				"$rustc"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}/chess"
+			},
+			"group": "build",
+			"label": "rust: cargo build release"
+		},
+		{
+			"type": "cargo",
+			"command": "run",
+			"problemMatcher": [
+				"$rustc"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}/chess"
+			},
+			"group": "build",
+			"label": "rust: cargo run debug"
+		},
+		{
+			"type": "cargo",
+			"command": "run",
+			"args": [
+				"--release"
+			],
+			"problemMatcher": [
+				"$rustc"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}/chess"
+			},
+			"group": "build",
+			"label": "rust: cargo run release"
+		},
+		{
+			"type": "cargo",
+			"command": "check",
+			"problemMatcher": [
+				"$rustc"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}/chess"
+			},
+			"group": "build",
+			"label": "rust: cargo check"
+		}
+		{
+			"type": "cargo",
+			"command": "test",
+			"problemMatcher": [
+				"$rustc"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}/chess"
+			},
+			"group": "build",
+			"label": "rust: cargo test"
+		},
+	]
+}


### PR DESCRIPTION
This PR adds VS Code tasks for the following cargo commands:

- `cargo build`
- `cargo build --release`
- `cargo run`
- `cargo run --release`
- `cargo check`
- `cargo test`

These tasks can be triggered via `CTRL + SHIFT + b`